### PR TITLE
Remove config from provider to make config:cache work

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ GOOGLE_DRIVE_CLIENT_SECRET=xxx
 GOOGLE_DRIVE_REFRESH_TOKEN=xxx
 GOOGLE_DRIVE_FOLDER=
 ```
-example
+config filesystem.php
 ```env
-FILESYSTEM_CLOUD=google
-GOOGLE_DRIVE_CLIENT_ID=xxx.apps.googleusercontent.com
-GOOGLE_DRIVE_CLIENT_SECRET=xxx
-GOOGLE_DRIVE_REFRESH_TOKEN=xxx
-GOOGLE_DRIVE_FOLDER=backups
+'disks' => [
+    'google' => [
+      'driver' => 'google',
+      'clientId' => env('GOOGLE_DRIVE_CLIENT_ID'),
+      'clientSecret' => env('GOOGLE_DRIVE_CLIENT_SECRET'),
+      'refreshToken' => env('GOOGLE_DRIVE_REFRESH_TOKEN'),
+      'folder' => env('GOOGLE_DRIVE_FOLDER'),
+    ]
+]
 ```
 
 ## Setup Google Keys

--- a/src/LaravelGoogleDriveStorageServiceProvider.php
+++ b/src/LaravelGoogleDriveStorageServiceProvider.php
@@ -28,15 +28,6 @@ class LaravelGoogleDriveStorageServiceProvider extends PackageServiceProvider
     public function bootingPackage()
     {
         try {
-            app()->config['filesystems.disks.google'] = [
-                'driver' => 'google',
-                'clientId' => env('GOOGLE_DRIVE_CLIENT_ID'),
-                'clientSecret' => env('GOOGLE_DRIVE_CLIENT_SECRET'),
-                'refreshToken' => env('GOOGLE_DRIVE_REFRESH_TOKEN'),
-                'folder' => env('GOOGLE_DRIVE_FOLDER'), // without folder is root of drive or team drive
-                //'teamDriveId' => env('GOOGLE_DRIVE_TEAM_DRIVE_ID'),
-            ];
-
             Storage::extend('google', function ($app, $config) {
                 $options = [];
 


### PR DESCRIPTION
When I used php artisan config:cache command all variables was null because you can't read from .env in your provider but only config files. [https://laracasts.com/discuss/channels/laravel/configcache-makes-variables-in-env-null](https://laracasts.com/discuss/channels/laravel/configcache-makes-variables-in-env-null)

